### PR TITLE
fix: add customPreStopCommand value

### DIFF
--- a/src/helm/blue-agent/templates/_helpers.tpl
+++ b/src/helm/blue-agent/templates/_helpers.tpl
@@ -172,6 +172,11 @@ containers:
               # For security reasons, force clean the tmpdir at restart -- Sharing data bewteen pipelines is a security risk
               rm -rf ${TMPDIR};
             {{- end }}
+            {{- else }}
+            - bash
+            - c
+            - true
+            {{- end }}
     {{- end }}
     env:
       - name: AGENT_DIAGLOGPATH

--- a/src/helm/blue-agent/values.yaml
+++ b/src/helm/blue-agent/values.yaml
@@ -66,6 +66,7 @@ pipelines:
     type: managed-csi
     # Enables the temp directory volume, default is true
     volumeEnabled: true
+  customPreStopCommand: []
 
 # Secret configuration
 secret:


### PR DESCRIPTION
# What was done:
- added `customPreStopCommand` to be able to customize `preStop` behavior
- using this value we should be able to prevent this [issue](https://github.com/clemlesne/blue-agent/issues/242)
