### PR TITLE
Enable user to set AZP_AGENT_ONCE=false

### DIFF
--- a/src/docker/start.sh
+++ b/src/docker/start.sh
@@ -177,7 +177,7 @@ if [ "$is_template_job" == "true" ]; then
   echo "Agent will be stopped after 1 min"
   # Run the agent for a minute
   timeout --preserve-status 1m bash run-docker.sh "$@" --once &
-else
+elif [ "$AZP_AGENT_ONETIME" == "true" ]; then
   # Unregister on success
   trap 'unregister; exit 0' EXIT
   # Unregister on Ctrl+C
@@ -188,6 +188,8 @@ else
   sleep 60 && unregister &
   # Run the agent
   bash run-docker.sh "$@" --once &
+else
+  bash run-docker.sh "$@" &
 fi
 
 # Fake the exit code of the agent for the prevent Kubernetes to detect the pod as failed (this is intended)

--- a/src/docker/start.sh
+++ b/src/docker/start.sh
@@ -177,7 +177,7 @@ if [ "$is_template_job" == "true" ]; then
   echo "Agent will be stopped after 1 min"
   # Run the agent for a minute
   timeout --preserve-status 1m bash run-docker.sh "$@" --once &
-elif [ "$AZP_AGENT_ONETIME" == "true" ]; then
+elif [ "${AZP_AGENT_ONETIME:-true}" == "true" ]; then
   # Unregister on success
   trap 'unregister; exit 0' EXIT
   # Unregister on Ctrl+C


### PR DESCRIPTION
Hi there! 

I had a need to have the agent run persistently in Kubernetes without shutting down (and triggering a CrashLoopBackoff). I was able to achieve this modifying the entrypoint to override the --once option. 

I realize this may not be useful for your setup, so feel free to reject if you don't like this, as I'm sure many people prefer one pod per job with the cleanup procedures - but for me, and for testing some basic ADO work, this seemed useful. 